### PR TITLE
fix: update Dewey MCP tool names after prefix drop (dewey#28)

### DIFF
--- a/internal/memory/proxy.go
+++ b/internal/memory/proxy.go
@@ -105,7 +105,7 @@ func (c *Client) Health() error {
 	return err
 }
 
-// Store proxies to dewey_dewey_store_learning with a deprecation warning.
+// Store proxies to store_learning with a deprecation warning.
 func (c *Client) Store(information, tags string) (map[string]any, error) {
 	params := map[string]any{
 		"information": information,
@@ -114,7 +114,7 @@ func (c *Client) Store(information, tags string) (map[string]any, error) {
 		params["tags"] = tags
 	}
 
-	result, err := c.Call("dewey_dewey_store_learning", params)
+	result, err := c.Call("store_learning", params)
 	if err != nil {
 		return nil, err
 	}
@@ -126,12 +126,12 @@ func (c *Client) Store(information, tags string) (map[string]any, error) {
 	}
 
 	// Add deprecation warning to response.
-	parsed["_warning"] = "hivemind_store is deprecated. Use dewey_dewey_store_learning directly."
+	parsed["_warning"] = "hivemind_store is deprecated. Use dewey_store_learning directly."
 
 	return parsed, nil
 }
 
-// Find proxies to dewey_dewey_semantic_search with a deprecation warning.
+// Find proxies to semantic_search with a deprecation warning.
 func (c *Client) Find(query, collection string, limit int) (map[string]any, error) {
 	params := map[string]any{
 		"query": query,
@@ -144,7 +144,7 @@ func (c *Client) Find(query, collection string, limit int) (map[string]any, erro
 		params["source_type"] = collection
 	}
 
-	result, err := c.Call("dewey_dewey_semantic_search", params)
+	result, err := c.Call("semantic_search", params)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (c *Client) Find(query, collection string, limit int) (map[string]any, erro
 	}
 
 	// Add deprecation warning to response.
-	parsed["_warning"] = "hivemind_find is deprecated. Use dewey_dewey_semantic_search directly."
+	parsed["_warning"] = "hivemind_find is deprecated. Use dewey_semantic_search directly."
 
 	return parsed, nil
 }

--- a/internal/memory/proxy_test.go
+++ b/internal/memory/proxy_test.go
@@ -132,8 +132,8 @@ func TestHealth_Failure(t *testing.T) {
 
 func TestStore_Success(t *testing.T) {
 	srv := newTestServer(t, func(method string, params json.RawMessage) (any, *jsonRPCError) {
-		if method != "dewey_dewey_store_learning" {
-			t.Errorf("method = %q, want %q", method, "dewey_dewey_store_learning")
+		if method != "store_learning" {
+			t.Errorf("method = %q, want %q", method, "store_learning")
 		}
 
 		var p map[string]string
@@ -199,8 +199,8 @@ func TestStore_DeweyUnavailable(t *testing.T) {
 
 func TestFind_Success(t *testing.T) {
 	srv := newTestServer(t, func(method string, params json.RawMessage) (any, *jsonRPCError) {
-		if method != "dewey_dewey_semantic_search" {
-			t.Errorf("method = %q, want %q", method, "dewey_dewey_semantic_search")
+		if method != "semantic_search" {
+			t.Errorf("method = %q, want %q", method, "semantic_search")
 		}
 
 		var p map[string]any

--- a/openspec/changes/dewey-mcp-name-change/.openspec.yaml
+++ b/openspec/changes/dewey-mcp-name-change/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-05

--- a/openspec/changes/dewey-mcp-name-change/design.md
+++ b/openspec/changes/dewey-mcp-name-change/design.md
@@ -1,0 +1,42 @@
+## Context
+
+Dewey PR #28 renamed 4 MCP tool registrations in `server.go`:
+
+| Before | After | Agent sees (OpenCode prefix) |
+|--------|-------|------------------------------|
+| `dewey_semantic_search` | `semantic_search` | `dewey_semantic_search` |
+| `dewey_similar` | `similar` | `dewey_similar` |
+| `dewey_semantic_search_filtered` | `semantic_search_filtered` | `dewey_semantic_search_filtered` |
+| `dewey_store_learning` | `store_learning` | `dewey_store_learning` |
+
+Replicator's `internal/memory/proxy.go` calls Dewey directly via HTTP JSON-RPC, using the **internal** MCP tool names. These are now wrong.
+
+There are two layers of naming:
+1. **Internal names** (used in direct HTTP calls to Dewey's MCP endpoint): `store_learning`, `semantic_search`
+2. **Agent-facing names** (what OpenCode agents see, with server prefix): `dewey_store_learning`, `dewey_semantic_search`
+
+## Goals / Non-Goals
+
+### Goals
+- Update internal tool names in `proxy.go` to match Dewey's new registrations
+- Update deprecation warning text to show correct agent-facing names
+- Update test assertions to match new names
+
+### Non-Goals
+- Changing the MCP protocol usage pattern (the `Call` method structure stays as-is)
+- Updating completed spec artifacts (historical records)
+- Modifying deprecated tool mappings (`deprecated.go` -- those reference agent-facing names which are unchanged)
+
+## Decisions
+
+**D1: Simple string replacement.** All 8 changes are string literal updates -- no logic, no schema, no type changes. The proxy's behavior is unchanged; only the tool name strings are different.
+
+**D2: Deprecation warnings use agent-facing names.** The `_warning` field in proxy responses tells agents what tool to use instead. These should show the OpenCode-prefixed names (`dewey_store_learning`, `dewey_semantic_search`) since that's what agents actually type.
+
+**D3: Leave spec artifacts as-is.** `specs/001-go-rewrite-phases/plan.md` and `tasks.md` reference the old names in historical task descriptions. Updating them adds noise to git history with no functional benefit.
+
+## Risks / Trade-offs
+
+**Risk: None.** This is a mechanical find-and-replace with no behavioral impact. The proxy sends the correct tool name, Dewey receives it, behavior is identical.
+
+**Trade-off: Not fixing the MCP protocol issue.** The `Call` method puts the tool name in the JSON-RPC `method` field rather than using standard `tools/call` with `params.name`. This works because Dewey accepts both patterns, but it's non-standard. Fixing this is out of scope for this change -- it would require restructuring the `Call` method and all tests.

--- a/openspec/changes/dewey-mcp-name-change/proposal.md
+++ b/openspec/changes/dewey-mcp-name-change/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+Dewey PR #28 dropped the `dewey_` prefix from 4 MCP tool registration names to eliminate the `dewey_dewey_*` double-prefix that appeared in OpenCode agent UIs. Replicator's memory proxy calls Dewey directly via HTTP JSON-RPC and references the old tool names. These calls now fail because Dewey no longer registers tools under those names.
+
+## What Changes
+
+### Modified Capabilities
+- `hivemind_store`: Update the Dewey proxy call from `dewey_dewey_store_learning` to `store_learning` (the new internal MCP tool name)
+- `hivemind_find`: Update the Dewey proxy call from `dewey_dewey_semantic_search` to `semantic_search` (the new internal MCP tool name)
+- Deprecation warning text: Update agent-facing tool names from `dewey_dewey_*` to `dewey_*` (the correct OpenCode-prefixed names)
+
+## Impact
+
+- `internal/memory/proxy.go` -- 2 tool name strings in `Call()` invocations, 2 deprecation warning strings, 2 comments
+- `internal/memory/proxy_test.go` -- 2 test assertions for expected method names
+- No behavioral changes -- same proxy logic, same error handling, same deprecation pattern
+- No changes to deprecated tool mappings (they reference agent-facing names like `dewey_search` which are unaffected)
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+This change updates a string constant in a proxy client. Replicator continues to communicate with Dewey through well-defined JSON-RPC artifacts. No coupling changes.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+Replicator remains independently installable. When Dewey is unavailable, the proxy returns structured `DEWEY_UNAVAILABLE` errors. This change does not introduce new dependencies.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The deprecation warnings in tool responses are updated to show the correct agent-facing tool names (`dewey_store_learning` instead of `dewey_dewey_store_learning`), improving the quality of guidance agents receive.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+Tests use `httptest.NewServer` to mock Dewey. The mock matches on the tool name string, so updating the test assertions maintains isolation without requiring a live Dewey instance.

--- a/openspec/changes/dewey-mcp-name-change/specs/tool-names.md
+++ b/openspec/changes/dewey-mcp-name-change/specs/tool-names.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Dewey proxy store tool name
+
+The `hivemind_store` proxy MUST call Dewey's MCP endpoint using the internal tool name `store_learning`.
+
+Previously: The proxy called `dewey_dewey_store_learning`.
+
+#### Scenario: Store a learning via proxy
+- **GIVEN** Dewey is available at the configured MCP endpoint
+- **WHEN** an agent calls `hivemind_store` with information and tags
+- **THEN** the proxy sends a JSON-RPC request to Dewey with method `store_learning`
+
+### Requirement: Dewey proxy find tool name
+
+The `hivemind_find` proxy MUST call Dewey's MCP endpoint using the internal tool name `semantic_search`.
+
+Previously: The proxy called `dewey_dewey_semantic_search`.
+
+#### Scenario: Search memories via proxy
+- **GIVEN** Dewey is available at the configured MCP endpoint
+- **WHEN** an agent calls `hivemind_find` with a query
+- **THEN** the proxy sends a JSON-RPC request to Dewey with method `semantic_search`
+
+### Requirement: Deprecation warnings reference agent-facing names
+
+Deprecation warnings in proxy responses MUST reference the correct agent-facing tool names: `dewey_store_learning` and `dewey_semantic_search` (with OpenCode's `dewey_` prefix, not the internal MCP name).
+
+Previously: Warnings referenced `dewey_dewey_store_learning` and `dewey_dewey_semantic_search`.
+
+#### Scenario: Store response includes correct deprecation hint
+- **GIVEN** an agent calls `hivemind_store` successfully
+- **WHEN** the response is returned
+- **THEN** the `_warning` field contains `dewey_store_learning` (not `dewey_dewey_store_learning`)

--- a/openspec/changes/dewey-mcp-name-change/tasks.md
+++ b/openspec/changes/dewey-mcp-name-change/tasks.md
@@ -1,0 +1,22 @@
+## 1. Update Dewey proxy tool names
+
+- [x] 1.1 In `internal/memory/proxy.go`, change `c.Call("dewey_dewey_store_learning", ...)` to `c.Call("store_learning", ...)`
+- [x] 1.2 In `internal/memory/proxy.go`, change `c.Call("dewey_dewey_semantic_search", ...)` to `c.Call("semantic_search", ...)`
+- [x] 1.3 In `internal/memory/proxy.go`, update the `Store` comment from `dewey_dewey_store_learning` to `store_learning`
+- [x] 1.4 In `internal/memory/proxy.go`, update the `Find` comment from `dewey_dewey_semantic_search` to `semantic_search`
+
+## 2. Update deprecation warnings
+
+- [x] 2.1 In `internal/memory/proxy.go`, change the Store `_warning` text from `"Use dewey_dewey_store_learning directly."` to `"Use dewey_store_learning directly."`
+- [x] 2.2 In `internal/memory/proxy.go`, change the Find `_warning` text from `"Use dewey_dewey_semantic_search directly."` to `"Use dewey_semantic_search directly."`
+
+## 3. Update tests
+
+- [x] 3.1 In `internal/memory/proxy_test.go`, update the Store test assertion from `"dewey_dewey_store_learning"` to `"store_learning"`
+- [x] 3.2 In `internal/memory/proxy_test.go`, update the Find test assertion from `"dewey_dewey_semantic_search"` to `"semantic_search"`
+
+## 4. Verify
+
+- [x] 4.1 Run `go vet ./...` -- zero warnings
+- [x] 4.2 Run `go test ./internal/memory/ -count=1 -v` -- all proxy tests pass with new tool names
+- [x] 4.3 Run `go test ./... -count=1` -- full suite passes, no regressions


### PR DESCRIPTION
## Summary

Dewey [PR #28](https://github.com/unbound-force/dewey/pull/28) dropped the `dewey_` prefix from 4 MCP tool registrations to eliminate the `dewey_dewey_*` double-prefix in OpenCode agent UIs.

This updates replicator's memory proxy to use the new internal tool names when calling Dewey directly via HTTP JSON-RPC:

- `store_learning` (was `dewey_dewey_store_learning`)
- `semantic_search` (was `dewey_dewey_semantic_search`)
- Deprecation warnings now show correct agent-facing names (`dewey_store_learning`, `dewey_semantic_search`)

All 11 packages pass, 20 memory proxy tests pass with updated assertions.