### PR TITLE
fix: add mode: subagent to agent frontmatter

### DIFF
--- a/internal/agentkit/content/agents/background-worker.md
+++ b/internal/agentkit/content/agents/background-worker.md
@@ -1,6 +1,8 @@
 ---
 name: background-worker
 description: Runs background tasks without MCP tool access.
+mode: subagent
+hidden: true
 ---
 
 # Background Worker

--- a/internal/agentkit/content/agents/coordinator.md
+++ b/internal/agentkit/content/agents/coordinator.md
@@ -1,6 +1,7 @@
 ---
 name: coordinator
 description: Orchestrates forge coordination and supervises worker agents.
+mode: subagent
 ---
 
 # Forge Coordinator

--- a/internal/agentkit/content/agents/worker.md
+++ b/internal/agentkit/content/agents/worker.md
@@ -1,6 +1,8 @@
 ---
 name: worker
 description: Executes a single subtask with file reservations and progress reporting.
+mode: subagent
+hidden: true
 ---
 
 # Forge Worker


### PR DESCRIPTION
## Summary

- Added `mode: subagent` to `coordinator.md`, `worker.md`, and `background-worker.md` YAML frontmatter
- Added `hidden: true` to `worker.md` and `background-worker.md` (internal agents, never user-invoked)

## Problem

All three agent files lacked a `mode:` field. OpenCode defaults agents without `mode` to `all`, making them appear as Tab-cyclable primary modes alongside Build and Plan. Users see unexpected modes after `replicator init` -- coordinator, worker, and background-worker -- with no explanation of what they are.

## Fix

- `coordinator.md`: `mode: subagent` -- invokable via `/forge` or programmatically, not via Tab
- `worker.md`: `mode: subagent` + `hidden: true` -- internal forge agent, hidden from `@` autocomplete
- `background-worker.md`: `mode: subagent` + `hidden: true` -- internal forge agent, hidden from `@` autocomplete

All agentkit and init tests pass.

Closes #12