### PR TITLE
fix: add missing name field to 7 scaffolded skill templates

### DIFF
--- a/internal/agentkit/agentkit_test.go
+++ b/internal/agentkit/agentkit_test.go
@@ -1,6 +1,7 @@
 package agentkit
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -148,5 +149,67 @@ func TestScaffold_FileCount(t *testing.T) {
 	}
 	if agents != 3 {
 		t.Errorf("agents = %d, want 3", agents)
+	}
+}
+
+func TestSkillTemplates_HaveNameField(t *testing.T) {
+	// Walk the embedded content filesystem and verify every SKILL.md
+	// has a "name: <directory-name>" field in its YAML frontmatter.
+	var checked int
+
+	err := fs.WalkDir(content, "content/skills", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Name() != "SKILL.md" {
+			return nil
+		}
+
+		data, readErr := content.ReadFile(path)
+		if readErr != nil {
+			t.Errorf("read %s: %v", path, readErr)
+			return nil
+		}
+
+		text := string(data)
+
+		// Extract directory name (e.g., "always-on-guidance" from
+		// "content/skills/always-on-guidance/SKILL.md").
+		dir := filepath.Dir(path)
+		dirName := filepath.Base(dir)
+
+		// Verify frontmatter delimiters exist.
+		if !strings.HasPrefix(text, "---\n") {
+			t.Errorf("%s: missing opening frontmatter delimiter", path)
+			return nil
+		}
+		endIdx := strings.Index(text[4:], "\n---")
+		if endIdx < 0 {
+			t.Errorf("%s: missing closing frontmatter delimiter", path)
+			return nil
+		}
+		frontmatter := text[4 : 4+endIdx]
+
+		// Check for "name: <dirName>" line.
+		wantLine := "name: " + dirName
+		found := false
+		for _, line := range strings.Split(frontmatter, "\n") {
+			if strings.TrimSpace(line) == wantLine {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("%s: frontmatter missing %q", path, wantLine)
+		}
+
+		checked++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk embedded skills: %v", err)
+	}
+	if checked != 7 {
+		t.Errorf("checked %d skill templates, want 7", checked)
 	}
 }

--- a/internal/agentkit/content/skills/always-on-guidance/SKILL.md
+++ b/internal/agentkit/content/skills/always-on-guidance/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: always-on-guidance
 description: Global coding rules and tool usage discipline
 tags: [always-on, coding, quality]
 ---

--- a/internal/agentkit/content/skills/forge-coordination/SKILL.md
+++ b/internal/agentkit/content/skills/forge-coordination/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: forge-coordination
 description: Multi-agent coordination patterns for forge sessions
 tags: [forge, coordination, multi-agent]
 ---

--- a/internal/agentkit/content/skills/forge-global/SKILL.md
+++ b/internal/agentkit/content/skills/forge-global/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: forge-global
 description: Cross-project forge coordination patterns
 tags: [forge, global, coordination]
 ---

--- a/internal/agentkit/content/skills/learning-systems/SKILL.md
+++ b/internal/agentkit/content/skills/learning-systems/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: learning-systems
 description: How the forge learns from outcomes
 tags: [learning, forge, insights]
 ---

--- a/internal/agentkit/content/skills/replicator-cli/SKILL.md
+++ b/internal/agentkit/content/skills/replicator-cli/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: replicator-cli
 description: Replicator CLI quick reference
 tags: [cli, reference, replicator]
 ---

--- a/internal/agentkit/content/skills/system-design/SKILL.md
+++ b/internal/agentkit/content/skills/system-design/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: system-design
 description: System design principles for clean architecture
 tags: [design, architecture, principles]
 ---

--- a/internal/agentkit/content/skills/testing-patterns/SKILL.md
+++ b/internal/agentkit/content/skills/testing-patterns/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: testing-patterns
 description: Go testing patterns for the replicator project
 tags: [testing, go, patterns]
 ---


### PR DESCRIPTION
## Summary

The 7 skill templates embedded in `internal/agentkit/content/skills/` were missing the required `name` field in their YAML frontmatter. OpenCode's skill discovery requires both `name` and `description` fields to register a skill. Without `name`, skills scaffolded by `replicator init` were invisible to the `skill` tool and could not be loaded.

## Changes

**7 SKILL.md templates** — added `name: <directory-name>` as the first frontmatter field:

| Template | Added field |
|----------|------------|
| `always-on-guidance/SKILL.md` | `name: always-on-guidance` |
| `forge-coordination/SKILL.md` | `name: forge-coordination` |
| `forge-global/SKILL.md` | `name: forge-global` |
| `learning-systems/SKILL.md` | `name: learning-systems` |
| `replicator-cli/SKILL.md` | `name: replicator-cli` |
| `system-design/SKILL.md` | `name: system-design` |
| `testing-patterns/SKILL.md` | `name: testing-patterns` |

**Regression test** — added `TestSkillTemplates_HaveNameField` in `internal/agentkit/agentkit_test.go` that walks the embedded filesystem and asserts every SKILL.md has a `name` field matching its directory name.

## Context

Discovered via [unbound-force/unbound-force#309](https://github.com/unbound-force/unbound-force/issues/309). The live copies in `unbound-force/unbound-force` are being fixed separately — this PR fixes the replicator scaffold source so future `replicator init` runs produce discoverable skills.

## Verification

- `make check` passes (vet + all tests)
- New test verifies all 7 templates and will catch future regressions

Closes #28

---

Signed-off-by: Yvonne Devlin <ydevlin@redhat.com>
Assisted-by: OpenCode (claude-opus-4-6)