### PR TITLE
chore: remove replicator.log from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ coverage.out
 .uf/replicator/*.db-shm
 .uf/replicator/*.db-wal
 .uf/replicator/*.lock
+.uf/replicator/*.log
 .uf/muti-mind/artifacts/
 .uf/mx-f/data/
 # Legacy tool directories (renamed to .uf/ in Spec 025)

--- a/.uf/replicator/replicator.log
+++ b/.uf/replicator/replicator.log
@@ -1,3 +1,0 @@
-2026/07/07 12:58:52 INFO tool call tool=forge_worktree_list duration=4.536739ms success=true
-2026/07/07 13:04:12 INFO tool call tool=hivemind_store duration=811.57µs success=true
-2026/07/07 13:04:17 INFO tool call tool=hivemind_store duration=646.586µs success=true


### PR DESCRIPTION
## Summary

Remove `.uf/replicator/replicator.log` from version control and add `.uf/replicator/*.log` to `.gitignore`. The file is a runtime artifact that was accidentally committed in PR #11 and flagged in PR #32.

Fixes #34